### PR TITLE
feat: avoid head request unless necessary

### DIFF
--- a/src/range.js
+++ b/src/range.js
@@ -24,10 +24,16 @@ export const decodeRangeHeader = (str) => {
  * Resolve a range to an absolute range.
  *
  * @param {import('multipart-byte-range').Range} range
- * @param {number} totalSize
- * @returns {import('multipart-byte-range').AbsoluteRange}
+ * @param {() => Promise<number>} getTotalSize
+ * @returns {Promise<import('multipart-byte-range').AbsoluteRange>}
  */
-export const resolveRange = ([first, last], totalSize) => [
-  first < 0 ? totalSize + first : first,
-  last ?? totalSize - 1
-]
+export const resolveRange = async ([first, last], getTotalSize) => {
+  let totalSize = 0
+  if (first < 0 || last == null) {
+    totalSize = await getTotalSize()
+  }
+  return [
+    first < 0 ? totalSize + first : first,
+    last ?? totalSize - 1
+  ]
+}

--- a/src/server.js
+++ b/src/server.js
@@ -82,7 +82,6 @@ const handleRange = async (bucket, key, range, options) => {
     if (!object) throw new NotFoundError('Object Not Found')
     return object.size
   }
-  await getTotalSize()
   const [first, last] = await resolveRange(range, getTotalSize)
   const contentLength = last - first + 1
 
@@ -119,8 +118,6 @@ const handleMultipartRange = async (bucket, key, ranges, options) => {
     totalSize = object.size
     return totalSize
   }
-  await getTotalSize()
-
   const resolvedRanges = await Promise.all(ranges.map(r => resolveRange(r, getTotalSize)))
 
   const getBytes = createBatchingByteGetter(async range => {

--- a/src/server.js
+++ b/src/server.js
@@ -6,6 +6,8 @@ import { createBatchingByteGetter } from './batch.js'
 
 export { MaxBatchSize } from './batch.js'
 
+class NotFoundError extends Error {}
+
 /**
  * @param {{ bucket: API.Bucket } & API.HandlerOptions} model
  * @returns {API.Handler}
@@ -20,13 +22,11 @@ export const handler = async ({ bucket, maxBatchSize }, request) => {
   const url = new URL(request.url)
   const key = url.pathname.slice(1)
 
-  const object = await bucket.head(key)
-  if (!object) return new Response('Object Not Found', { status: 404 })
-
-  const headers = new Headers()
-  headers.set('Etag', object.httpEtag)
-
   if (request.method === 'HEAD') {
+    const object = await bucket.head(key)
+    if (!object) return new Response('Object Not Found', { status: 404 })
+    const headers = new Headers()
+    headers.set('Etag', object.httpEtag)
     headers.set('Accept-Ranges', 'bytes')
     headers.set('Content-Length', object.size.toString())
     return new Response(undefined, { headers })
@@ -46,45 +46,59 @@ export const handler = async ({ bucket, maxBatchSize }, request) => {
     }
   }
 
+  const headers = new Headers()
   headers.set('X-Content-Type-Options', 'nosniff')
   headers.set('Content-Type', 'application/octet-stream')
-  headers.set('Etag', object.httpEtag)
   headers.set('Cache-Control', 'public, max-age=29030400, immutable')
   headers.set('Vary', 'Range')
 
-  if (ranges.length > 1) {
-    return handleMultipartRange(bucket, key, object.size, ranges, { headers, maxBatchSize })
-  } else if (ranges.length === 1) {
-    return handleRange(bucket, key, object.size, ranges[0], { headers })
-  }
+  try {
+    if (ranges.length > 1) {
+      return await handleMultipartRange(bucket, key, ranges, { headers, maxBatchSize })
+    } else if (ranges.length === 1) {
+      return await handleRange(bucket, key, ranges[0], { headers })
+    }
 
-  // no range is effectively Range: bytes=0-
-  return handleRange(bucket, key, object.size, [0], { headers })
+    // no range is effectively Range: bytes=0-
+    return await handleRange(bucket, key, [0], { headers })
+  } catch (err) {
+    if (err instanceof NotFoundError) {
+      return new Response('Object Not Found', { status: 404 })
+    }
+    console.error(err)
+    return new Response('Internal Server Error', { status: 500 })
+  }
 }
 
 /**
  * @param {API.Bucket} bucket
  * @param {string} key
- * @param {number} size
  * @param {import('multipart-byte-range').Range} range
  * @param {{ headers?: Headers }} [options]
  */
-const handleRange = async (bucket, key, size, range, options) => {
-  const [first, last] = resolveRange(range, size)
+const handleRange = async (bucket, key, range, options) => {
+  const getTotalSize = async () => {
+    const object = await bucket.head(key)
+    if (!object) throw new NotFoundError('Object Not Found')
+    return object.size
+  }
+  await getTotalSize()
+  const [first, last] = await resolveRange(range, getTotalSize)
   const contentLength = last - first + 1
+
+  const object = await bucket.get(key, { range: { offset: first, length: contentLength } })
+  if (!object || !object.body) throw new Error('Object Not Found')
 
   const headers = new Headers(options?.headers)
   headers.set('Content-Length', String(contentLength))
 
-  if (size !== contentLength) {
-    const contentRange = `bytes ${first}-${last}/${size}`
+  if (object.size !== contentLength) {
+    const contentRange = `bytes ${first}-${last}/${object.size}`
     headers.set('Content-Range', contentRange)
   }
+  headers.set('Etag', object.httpEtag)
 
-  const status = size === contentLength ? 200 : 206
-  const object = await bucket.get(key, { range: { offset: first, length: contentLength } })
-  if (!object || !object.body) throw new Error('Object Not Found')
-
+  const status = object.size === contentLength ? 200 : 206
   const source = /** @type {ReadableStream} */ (object.body)
   return new Response(source, { status, headers })
 }
@@ -92,18 +106,30 @@ const handleRange = async (bucket, key, size, range, options) => {
 /**
  * @param {API.Bucket} bucket
  * @param {string} key
- * @param {number} size
  * @param {import('multipart-byte-range').Range[]} ranges
  * @param {{ headers?: Headers, maxBatchSize?: number }} [options]
  */
-const handleMultipartRange = async (bucket, key, size, ranges, options) => {
+const handleMultipartRange = async (bucket, key, ranges, options) => {
+  /** @type {number|undefined} */
+  let totalSize
+  const getTotalSize = async () => {
+    if (totalSize != null) return totalSize
+    const object = await bucket.head(key)
+    if (!object) throw new NotFoundError('Object Not Found')
+    totalSize = object.size
+    return totalSize
+  }
+  await getTotalSize()
+
+  const resolvedRanges = await Promise.all(ranges.map(r => resolveRange(r, getTotalSize)))
+
   const getBytes = createBatchingByteGetter(async range => {
     const options = { range: { offset: range[0], length: range[1] - range[0] + 1 } }
     const object = await bucket.get(key, options)
     if (!object || !object.body) throw new Error('Object Not Found')
     return /** @type {ReadableStream} */ (object.body)
-  }, ranges.map(r => resolveRange(r, size)), { maxSize: options?.maxBatchSize })
-  const source = new MultipartByteRangeEncoder(ranges, getBytes, { totalSize: size })
+  }, resolvedRanges, { maxSize: options?.maxBatchSize })
+  const source = new MultipartByteRangeEncoder(ranges, getBytes, { totalSize })
 
   const headers = new Headers(options?.headers)
   for (const [k, v] of Object.entries(source.headers)) {

--- a/test/test.spec.js
+++ b/test/test.spec.js
@@ -93,7 +93,7 @@ export const test = {
         write (part) {
           const range = ranges[partsCount]
           const headers = decodePartHeader(part.header)
-          assert.equal(headers.get('content-range'), `bytes ${range[0]}-${range[1]}/${value.length}`)
+          assert.equal(headers.get('content-range'), `bytes ${range[0]}-${range[1]}/*`)
           assert.deepEqual(
             part.content,
             value.subarray(range[0], range[1] + 1)


### PR DESCRIPTION
This avoids an additional HEAD request unless it absolutely needed.

It's needed when you request a open range (`100-` for example).

The potentially breaking change (except it's not since we don't rely on it) is that for multipart requests, the `Content-Range` response header now does not include the total length unless you've asked for an open-ended range. i.e. you used to get `Content-Range: bytes 1-3/8` and you now get `Content-Range: bytes 1-3/*`.