### PR TITLE
feat(batch): do not block batch fetch for last part

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "@httpland/range-parser": "^1.2.0",
+    "@opentelemetry/api": "^1.9.0",
     "multipart-byte-range": "^3.0.1",
     "p-defer": "^4.0.1",
     "uint8arraylist": "^2.4.8"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "c8": "^9.1.0",
     "entail": "^2.1.2",
     "standard": "^17.1.0",
-    "typescript": "^5.4.5",
+    "typescript": "^5.7.2",
     "uint8arrays": "^5.1.0"
   },
   "repository": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@httpland/range-parser':
         specifier: ^1.2.0
         version: 1.2.0
+      '@opentelemetry/api':
+        specifier: ^1.9.0
+        version: 1.9.0
       multipart-byte-range:
         specifier: ^3.0.1
         version: 3.0.1
@@ -111,6 +114,10 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@opentelemetry/api@1.9.0':
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
 
   '@types/istanbul-lib-coverage@2.0.6':
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
@@ -1326,6 +1333,8 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.17.1
 
+  '@opentelemetry/api@1.9.0': {}
+
   '@types/istanbul-lib-coverage@2.0.6': {}
 
   '@types/json5@0.0.29': {}
@@ -1672,12 +1681,12 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-standard-jsx@11.0.0(eslint-plugin-react@7.34.1)(eslint@8.57.0):
+  eslint-config-standard-jsx@11.0.0(eslint-plugin-react@7.34.1(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       eslint: 8.57.0
       eslint-plugin-react: 7.34.1(eslint@8.57.0)
 
-  eslint-config-standard@17.1.0(eslint-plugin-import@2.29.1)(eslint-plugin-n@15.7.0)(eslint-plugin-promise@6.1.1)(eslint@8.57.0):
+  eslint-config-standard@17.1.0(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint-plugin-n@15.7.0(eslint@8.57.0))(eslint-plugin-promise@6.1.1(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       eslint: 8.57.0
       eslint-plugin-import: 2.29.1(eslint@8.57.0)
@@ -1695,6 +1704,7 @@ snapshots:
   eslint-module-utils@2.8.1(eslint-import-resolver-node@0.3.9)(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
+    optionalDependencies:
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
     transitivePeerDependencies:
@@ -2465,8 +2475,8 @@ snapshots:
   standard@17.1.0:
     dependencies:
       eslint: 8.57.0
-      eslint-config-standard: 17.1.0(eslint-plugin-import@2.29.1)(eslint-plugin-n@15.7.0)(eslint-plugin-promise@6.1.1)(eslint@8.57.0)
-      eslint-config-standard-jsx: 11.0.0(eslint-plugin-react@7.34.1)(eslint@8.57.0)
+      eslint-config-standard: 17.1.0(eslint-plugin-import@2.29.1(eslint@8.57.0))(eslint-plugin-n@15.7.0(eslint@8.57.0))(eslint-plugin-promise@6.1.1(eslint@8.57.0))(eslint@8.57.0)
+      eslint-config-standard-jsx: 11.0.0(eslint-plugin-react@7.34.1(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-import: 2.29.1(eslint@8.57.0)
       eslint-plugin-n: 15.7.0(eslint@8.57.0)
       eslint-plugin-promise: 6.1.1(eslint@8.57.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,8 +40,8 @@ importers:
         specifier: ^17.1.0
         version: 17.1.0
       typescript:
-        specifier: ^5.4.5
-        version: 5.4.5
+        specifier: ^5.7.2
+        version: 5.7.2
       uint8arrays:
         specifier: ^5.1.0
         version: 5.1.0
@@ -1178,8 +1178,8 @@ packages:
     resolution: {integrity: sha512-/OxDN6OtAk5KBpGb28T+HZc2M+ADtvRxXrKKbUwtsLgdoxgX13hyy7ek6bFRl5+aBs2yZzB0c4CnQfAtVypW/g==}
     engines: {node: '>= 0.4'}
 
-  typescript@5.4.5:
-    resolution: {integrity: sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==}
+  typescript@5.7.2:
+    resolution: {integrity: sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -2604,7 +2604,7 @@ snapshots:
       is-typed-array: 1.1.13
       possible-typed-array-names: 1.0.0
 
-  typescript@5.4.5: {}
+  typescript@5.7.2: {}
 
   uint8arraylist@2.4.8:
     dependencies:


### PR DESCRIPTION
# Goals

While TTFB has been resolved by #6 , I noticed that the multipart fetches were still extremely slow (3-4) compared to the simple range fetch in blob-fetcher for the complete bounds. Looking at this code, this appears to be because the underlying implementation converts multipart back to a single range fetch, BUT the parts are not resolved until the entire range fetch completes.

# Implementation

- This PR removes the block that prevents any data from being sent until the entire R2 request is consumbed. It resolves parts as soon as it receives them so they can go over the wire.
- it also adds a trace span for the consumption itself

# For discussion

Comparison traces:

Before fix:
![Screenshot 2025-01-07 at 2 26 20 PM](https://github.com/user-attachments/assets/ec427632-26d9-4e56-b10c-4febcf7bef2b)

After Fix:
![Screenshot 2025-01-07 at 2 28 03 PM](https://github.com/user-attachments/assets/51ea9d21-80cf-4610-9b24-7fc7595c7948)
